### PR TITLE
Add 0.12 and io.js to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "io.js"


### PR DESCRIPTION
Optimally shipit should work on all three versions.