### PR TITLE
Track revisions

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -76,22 +76,23 @@ Shipit.getCurrentReleaseDirname = function() {
  * @param {int} backFromCurrent Number of releases back, starting from current
  */
 
-Shipit.getPreviousReleaseDirname = function() {
+Shipit.getPreviousReleaseDirname = function(backFromCurrent) {
   var shipit = this;
+  backFromCurrent = parseInt(backFromCurrent || 1, 10);
 
-  return shipit.remote('readlink ' + shipit.currentPath)
-  .then(function (results) {
-    if (!results) {
-      return shipit.log('No current release found.');
+  return shipit.getCurrentReleaseDirname().then(function(currentRelease) {
+
+    if (!currentRelease) {
+      return false;
     }
 
-    var releaseDirnames = results.map(computeReleaseDirname);
-
-    if (!equalValues(releaseDirnames))
-      throw new Error('Remote server are not synced.');
-
-    return releaseDirnames[0];
+    return shipit.getReleases().then(function(releases) {
+      var currentReleaseIndex = releases.indexOf(currentRelease);
+      var releaseIndex = currentReleaseIndex + backFromCurrent;
+      return releaseIndex !== -1 ? releases[releaseIndex] : false;
+    });
   });
+
 };
 
 Shipit.getReleases = function() {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -108,5 +108,6 @@ module.exports = function releases(shipit) {
   return _.assign(shipit, {
     getCurrentReleaseDirname: getCurrentReleaseDirname,
     getPreviousReleaseDirname: getPreviousReleaseDirname,
+    getReleases: getReleases,
   });
 };

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -78,7 +78,11 @@ module.exports = function releases(shipit) {
 
   var getCurrentReleaseDirname = function getCurrentReleaseDirname() {
     return shipit.remote('readlink ' + shipit.currentPath)
+
     .then(function (results) {
+      if (!results)
+        return shipit.log('No current release found.');
+
       var releaseDirnames = results.map(computeReleaseDirname);
 
       if (!equalValues(releaseDirnames))

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,0 +1,112 @@
+var path = require('path');
+var _ = require('lodash');
+
+module.exports = function releases(shipit) {
+
+  /**
+   * Test if all values are equal.
+   *
+   * @param {*[]} values
+   * @returns {boolean}
+   */
+
+  var equalValues = function equalValues(values) {
+    return values.every(function (value) {
+      return _.isEqual(value, values[0]);
+    });
+  };
+
+  /**
+   * Compute the current release dir name.
+   *
+   * @param {object} result
+   * @returns {string}
+   */
+
+  var computeReleaseDirname = function computeReleaseDirname(result) {
+    if (!result.stdout) return null;
+
+    // Trim last breakline.
+    var target = result.stdout.replace(/\n$/, '');
+
+    return target.split(path.sep).pop();
+  };
+
+  /**
+   * Compute the current release dir name.
+   *
+   * @param {object} result
+   * @returns {string}
+   */
+
+  var computeReleases = function computeReleases(result) {
+    if (!result.stdout) return null;
+
+    // Trim last breakline.
+    var dirs = result.stdout.replace(/\n$/, '');
+
+    // Convert releases to an array.
+    return dirs.split('\n');
+  };
+
+  /**
+   * Return a specified release dirname.
+   *
+   * @param {int} backFromCurrent Number of releases back, starting from current
+   */
+
+  var getPreviousReleaseDirname = function getPreviousReleaseDirname(backFromCurrent) {
+    backFromCurrent = parseInt(backFromCurrent || 1, 10);
+
+    return getCurrentReleaseDirname().then(function(currentRelease) {
+
+      if (!currentRelease) {
+        return false;
+      }
+
+      return getReleases().then(function(releases) {
+        var currentReleaseIndex = releases.indexOf(currentRelease);
+        var releaseIndex = currentReleaseIndex + backFromCurrent;
+        return releaseIndex !== -1 ? releases[releaseIndex] : false;
+      });
+    });
+  };
+
+  /**
+   * Return the current release dirname.
+   */
+
+  var getCurrentReleaseDirname = function getCurrentReleaseDirname() {
+    return shipit.remote('readlink ' + shipit.currentPath)
+    .then(function (results) {
+      var releaseDirnames = results.map(computeReleaseDirname);
+
+      if (!equalValues(releaseDirnames))
+        throw new Error('Remote server are not synced.');
+
+      return releaseDirnames[0];
+    });
+  };
+
+  /**
+   * Return all remote releases.
+   */
+
+  var getReleases = function getReleases(argument) {
+    return shipit.remote('ls -r1 ' + shipit.releasesPath)
+    .then(function (results) {
+      var releases = results.map(computeReleases);
+
+      if (!equalValues(releases))
+        throw new Error('Remote server are not synced.');
+
+      return releases[0];
+    });
+  };
+
+
+  return _.assign(shipit, {
+    getCurrentReleaseDirname: getCurrentReleaseDirname,
+    getPreviousReleaseDirname: getPreviousReleaseDirname,
+  });
+};

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,117 +1,110 @@
 var path = require('path');
 var _ = require('lodash');
 
-module.exports = function releases(shipit) {
+var Shipit = module.exports;
 
-  /**
-   * Test if all values are equal.
-   *
-   * @param {*[]} values
-   * @returns {boolean}
-   */
+/**
+ * Compute the current release dir name.
+ *
+ * @param {object} result
+ * @returns {string}
+ */
 
-  var equalValues = function equalValues(values) {
-    return values.every(function (value) {
-      return _.isEqual(value, values[0]);
-    });
-  };
+var computeReleases = function computeReleases(result) {
+  if (!result.stdout) return null;
 
-  /**
-   * Compute the current release dir name.
-   *
-   * @param {object} result
-   * @returns {string}
-   */
+  // Trim last breakline.
+  var dirs = result.stdout.replace(/\n$/, '');
 
-  var computeReleaseDirname = function computeReleaseDirname(result) {
-    if (!result.stdout) return null;
+  // Convert releases to an array.
+  return dirs.split('\n');
+};
 
-    // Trim last breakline.
-    var target = result.stdout.replace(/\n$/, '');
+/**
+ * Test if all values are equal.
+ *
+ * @param {*[]} values
+ * @returns {boolean}
+ */
 
-    return target.split(path.sep).pop();
-  };
-
-  /**
-   * Compute the current release dir name.
-   *
-   * @param {object} result
-   * @returns {string}
-   */
-
-  var computeReleases = function computeReleases(result) {
-    if (!result.stdout) return null;
-
-    // Trim last breakline.
-    var dirs = result.stdout.replace(/\n$/, '');
-
-    // Convert releases to an array.
-    return dirs.split('\n');
-  };
-
-  /**
-   * Return a specified release dirname.
-   *
-   * @param {int} backFromCurrent Number of releases back, starting from current
-   */
-
-  var getPreviousReleaseDirname = function getPreviousReleaseDirname(backFromCurrent) {
-    backFromCurrent = parseInt(backFromCurrent || 1, 10);
-
-    return getCurrentReleaseDirname().then(function(currentRelease) {
-
-      if (!currentRelease) {
-        return false;
-      }
-
-      return getReleases().then(function(releases) {
-        var currentReleaseIndex = releases.indexOf(currentRelease);
-        var releaseIndex = currentReleaseIndex + backFromCurrent;
-        return releaseIndex !== -1 ? releases[releaseIndex] : false;
-      });
-    });
-  };
-
-  /**
-   * Return the current release dirname.
-   */
-
-  var getCurrentReleaseDirname = function getCurrentReleaseDirname() {
-    return shipit.remote('readlink ' + shipit.currentPath)
-
-    .then(function (results) {
-      if (!results)
-        return shipit.log('No current release found.');
-
-      var releaseDirnames = results.map(computeReleaseDirname);
-
-      if (!equalValues(releaseDirnames))
-        throw new Error('Remote server are not synced.');
-
-      return releaseDirnames[0];
-    });
-  };
-
-  /**
-   * Return all remote releases.
-   */
-
-  var getReleases = function getReleases(argument) {
-    return shipit.remote('ls -r1 ' + shipit.releasesPath)
-    .then(function (results) {
-      var releases = results.map(computeReleases);
-
-      if (!equalValues(releases))
-        throw new Error('Remote server are not synced.');
-
-      return releases[0];
-    });
-  };
-
-
-  return _.assign(shipit, {
-    getCurrentReleaseDirname: getCurrentReleaseDirname,
-    getPreviousReleaseDirname: getPreviousReleaseDirname,
-    getReleases: getReleases,
+var equalValues = function equalValues(values) {
+  return values.every(function (value) {
+    return _.isEqual(value, values[0]);
   });
 };
+
+/**
+ * Compute the current release dir name.
+ *
+ * @param {object} result
+ * @returns {string}
+ */
+
+var computeReleaseDirname = function computeReleaseDirname(result) {
+  if (!result.stdout) return null;
+
+  // Trim last breakline.
+  var target = result.stdout.replace(/\n$/, '');
+
+  return target.split(path.sep).pop();
+};
+
+/**
+ * Return the current release dirname.
+ */
+
+Shipit.getCurrentReleaseDirname = function() {
+  var shipit = this;
+
+  return shipit.remote('readlink ' + shipit.currentPath)
+  .then(function (results) {
+    if (!results)
+      return shipit.log('No current release found.');
+
+    var releaseDirnames = results.map(computeReleaseDirname);
+
+    if (!equalValues(releaseDirnames))
+      throw new Error('Remote server are not synced.');
+
+    return releaseDirnames[0];
+  });
+};
+
+/**
+ * Return a specified release dirname.
+ *
+ * @param {int} backFromCurrent Number of releases back, starting from current
+ */
+
+Shipit.getPreviousReleaseDirname = function() {
+  var shipit = this;
+
+  return shipit.remote('readlink ' + shipit.currentPath)
+  .then(function (results) {
+    if (!results) {
+      return shipit.log('No current release found.');
+    }
+
+    var releaseDirnames = results.map(computeReleaseDirname);
+
+    if (!equalValues(releaseDirnames))
+      throw new Error('Remote server are not synced.');
+
+    return releaseDirnames[0];
+  });
+};
+
+Shipit.getReleases = function() {
+  var shipit = this;
+
+  return shipit.remote('ls -r1 ' + shipit.releasesPath)
+  .then(function (results) {
+    var releases = results.map(computeReleases);
+
+    if (!equalValues(releases))
+      throw new Error('Remote server are not synced.');
+
+    return releases[0];
+  });
+};
+

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -10,7 +10,7 @@ var Shipit = module.exports;
  * @returns {string}
  */
 
-var computeReleases = function computeReleases(result) {
+function computeReleases(result) {
   if (!result.stdout) return null;
 
   // Trim last breakline.
@@ -18,7 +18,7 @@ var computeReleases = function computeReleases(result) {
 
   // Convert releases to an array.
   return dirs.split('\n');
-};
+}
 
 /**
  * Test if all values are equal.
@@ -27,11 +27,11 @@ var computeReleases = function computeReleases(result) {
  * @returns {boolean}
  */
 
-var equalValues = function equalValues(values) {
+function equalValues(values) {
   return values.every(function (value) {
     return _.isEqual(value, values[0]);
   });
-};
+}
 
 /**
  * Compute the current release dir name.
@@ -40,14 +40,14 @@ var equalValues = function equalValues(values) {
  * @returns {string}
  */
 
-var computeReleaseDirname = function computeReleaseDirname(result) {
+function computeReleaseDirname(result) {
   if (!result.stdout) return null;
 
   // Trim last breakline.
   var target = result.stdout.replace(/\n$/, '');
 
   return target.split(path.sep).pop();
-};
+}
 
 /**
  * Return the current release dirname.
@@ -80,13 +80,15 @@ Shipit.getPreviousReleaseDirname = function(backFromCurrent) {
   var shipit = this;
   backFromCurrent = parseInt(backFromCurrent || 1, 10);
 
-  return shipit.getCurrentReleaseDirname().then(function(currentRelease) {
+  return shipit.getCurrentReleaseDirname()
+  .then(function(currentRelease) {
 
     if (!currentRelease) {
       return false;
     }
 
-    return shipit.getReleases().then(function(releases) {
+    return shipit.getReleases()
+    .then(function(releases) {
       var currentReleaseIndex = releases.indexOf(currentRelease);
       var releaseIndex = currentReleaseIndex + backFromCurrent;
       return releaseIndex !== -1 ? releases[releaseIndex] : false;
@@ -113,7 +115,8 @@ Shipit.getRevision = function(releaseDir) {
   var shipit = this;
   var file = path.join(shipit.releasesPath, releaseDir, 'REVISION');
 
-  return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;').then(function(response) {
+  return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;')
+  .then(function(response) {
 
     // TODO: How should we handle multiple?
     return response[0].stdout.trim();

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -109,3 +109,13 @@ Shipit.getReleases = function() {
   });
 };
 
+Shipit.getRevision = function(releaseDir) {
+  var shipit = this;
+  var file = path.join(shipit.releasesPath, releaseDir, 'REVISION');
+
+  return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;').then(function(response) {
+
+    // TODO: How should we handle multiple?
+    return response[0].stdout.trim();
+  });
+};

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -58,8 +58,10 @@ Shipit.getCurrentReleaseDirname = function() {
 
   return shipit.remote('readlink ' + shipit.currentPath)
   .then(function (results) {
-    if (!results)
-      return shipit.log('No current release found.');
+    if (!results) {
+      shipit.log('No current release found.');
+      return null;
+    }
 
     var releaseDirnames = results.map(computeReleaseDirname);
 
@@ -84,14 +86,14 @@ Shipit.getPreviousReleaseDirname = function(backFromCurrent) {
   .then(function(currentRelease) {
 
     if (!currentRelease) {
-      return false;
+      return null;
     }
 
     return shipit.getReleases()
     .then(function(releases) {
       var currentReleaseIndex = releases.indexOf(currentRelease);
       var releaseIndex = currentReleaseIndex + backFromCurrent;
-      return releaseIndex !== -1 ? releases[releaseIndex] : false;
+      return releaseIndex !== -1 ? releases[releaseIndex] : null;
     });
   });
 

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -64,7 +64,7 @@ Shipit.getCurrentReleaseDirname = function() {
     var releaseDirnames = results.map(computeReleaseDirname);
 
     if (!equalValues(releaseDirnames))
-      throw new Error('Remote server are not synced.');
+      throw new Error('Remote servers are not synced.');
 
     return releaseDirnames[0];
   });
@@ -103,7 +103,7 @@ Shipit.getReleases = function() {
     var releases = results.map(computeReleases);
 
     if (!equalValues(releases))
-      throw new Error('Remote server are not synced.');
+      throw new Error('Remote servers are not synced.');
 
     return releases[0];
   });

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -119,8 +119,6 @@ Shipit.getRevision = function(releaseDir) {
 
   return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;')
   .then(function(response) {
-
-    // TODO: How should we handle multiple?
     return response[0].stdout.trim();
   });
 };

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -99,6 +99,10 @@ Shipit.getPreviousReleaseDirname = function(backFromCurrent) {
 
 };
 
+/**
+ * Return all remote releases.
+ */
+
 Shipit.getReleases = function() {
   var shipit = this;
 
@@ -112,6 +116,12 @@ Shipit.getReleases = function() {
     return releases[0];
   });
 };
+
+/**
+ * Return SHA from remote REVISION file.
+ *
+ * @param {string} releaseDir Directory name of the relesase dir (YYYYMMDDHHmmss).
+ */
 
 Shipit.getRevision = function(releaseDir) {
   var shipit = this;

--- a/tasks/deploy/init.js
+++ b/tasks/deploy/init.js
@@ -1,6 +1,6 @@
 var registerTask = require('../../lib/register-task');
 var getShipit = require('../../lib/get-shipit');
-var path = require('path');
+var path = require('path2/posix');
 
 /**
  * Init task.

--- a/tasks/deploy/init.js
+++ b/tasks/deploy/init.js
@@ -1,5 +1,6 @@
 var registerTask = require('../../lib/register-task');
 var getShipit = require('../../lib/get-shipit');
+var path = require('path2/posix');
 
 /**
  * Init task.
@@ -11,6 +12,8 @@ module.exports = function (gruntOrShipit) {
 
   function task() {
     var shipit = getShipit(gruntOrShipit);
+    shipit.currentPath = path.join(shipit.config.deployTo, 'current');
+    shipit.releasesPath = path.join(shipit.config.deployTo, 'releases');
     shipit.emit('deploy');
   }
 };

--- a/tasks/deploy/init.js
+++ b/tasks/deploy/init.js
@@ -1,6 +1,6 @@
 var registerTask = require('../../lib/register-task');
 var getShipit = require('../../lib/get-shipit');
-var path = require('path2/posix');
+var path = require('path');
 
 /**
  * Init task.

--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -26,7 +26,6 @@ module.exports = function (gruntOrShipit) {
     function updateSymbolicLink() {
       shipit.log('Publishing release "%s"', shipit.releasePath);
 
-      shipit.currentPath = path.join(shipit.config.deployTo, 'current');
       var relativeReleasePath = path.join('releases', shipit.releaseDirname);
 
       return shipit.remote('cd ' + shipit.config.deployTo + ' && ln -nfs ' + relativeReleasePath + ' current')

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -7,7 +7,9 @@ var _ = require('lodash');
 
 /**
  * Update task.
+ * - Set previous revision.
  * - Create and define release path.
+ * - Set current revision and write REVISION file.
  * - Remote copy project.
  */
 
@@ -55,6 +57,10 @@ module.exports = function (gruntOrShipit) {
       });
     }
 
+    /**
+     * Set shipit.previousRevision from remote REVISION file
+     */
+
     function setPreviousRevision() {
       return shipit.getPreviousReleaseDirname().then(function(previousReleaseDir) {
         var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
@@ -69,6 +75,10 @@ module.exports = function (gruntOrShipit) {
         shipit.previousRevision = revision;
       });
     }
+
+    /**
+     * Set shipit.currentRevision and write it to REVISION file.
+     */
 
     function setCurrentRevision() {
       shipit.log('Setting current revision and creating revision file.');

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -3,6 +3,7 @@ var getShipit = require('../../lib/get-shipit');
 var path = require('path2/posix');
 var moment = require('moment');
 var chalk = require('chalk');
+var _ = require('lodash');
 
 /**
  * Update task.
@@ -14,7 +15,8 @@ module.exports = function (gruntOrShipit) {
   registerTask(gruntOrShipit, 'deploy:update', task);
 
   function task() {
-    var shipit = require('../../lib/releases')(getShipit(gruntOrShipit));
+    var shipit = getShipit(gruntOrShipit);
+    _.assign(shipit.constructor.prototype, require('../../lib/releases'));
 
     return setPreviousRevision()
     .then(createReleasePath)

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -63,7 +63,7 @@ module.exports = function (gruntOrShipit) {
 
     function setPreviousRevision() {
       return shipit.getPreviousReleaseDirname().then(function(previousReleaseDir) {
-        var previousRevision = false;
+        var previousRevision = null;
 
         if (previousReleaseDir) {
           return shipit.getRevision(previousReleaseDir).then(function(revision) {

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -18,7 +18,7 @@ module.exports = function (gruntOrShipit) {
 
   function task() {
     var shipit = getShipit(gruntOrShipit);
-    _.assign(shipit.constructor.prototype, require('../../lib/releases'));
+    _.assign(shipit.constructor.prototype, require('../../lib/shipit'));
 
     return setPreviousRevision()
     .then(createReleasePath)
@@ -63,16 +63,18 @@ module.exports = function (gruntOrShipit) {
 
     function setPreviousRevision() {
       return shipit.getPreviousReleaseDirname().then(function(previousReleaseDir) {
-        var revision = false;
-        if (previousReleaseDir) {
-          var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
-          return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;').then(function(response) {
+        var previousRevision = false;
 
-            // TODO: How should we handle multiple?
-            revision = response[0].stdout.trim();
+        if (previousReleaseDir) {
+          return shipit.getRevision(previousReleaseDir).then(function(revision) {
+            if (revision) {
+              shipit.log(chalk.green('Previous revision found.'));
+              previousRevision = revision;
+            }
           });
         }
-        shipit.previousRevision = revision;
+
+        shipit.previousRevision = previousRevision;
       });
     }
 

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -57,15 +57,16 @@ module.exports = function (gruntOrShipit) {
 
     function setPreviousRevision() {
       return shipit.getPreviousReleaseDirname().then(function(previousReleaseDir) {
+        var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
+        var revision = false;
         if (previousReleaseDir) {
-          var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
           return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;').then(function(response) {
 
             // TODO: How should we handle multiple?
-            var rev = response[0].stdout.trim();
-            shipit.previousRevision = rev || false;
+            revision = response[0].stdout.trim();
           });
         }
+        shipit.previousRevision = revision;
       });
     }
 

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -63,9 +63,9 @@ module.exports = function (gruntOrShipit) {
 
     function setPreviousRevision() {
       return shipit.getPreviousReleaseDirname().then(function(previousReleaseDir) {
-        var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
         var revision = false;
         if (previousReleaseDir) {
+          var file = path.join(shipit.releasesPath, previousReleaseDir, 'REVISION');
           return shipit.remote('if [ -f ' + file + ' ]; then cat ' + file + ' 2>/dev/null; fi;').then(function(response) {
 
             // TODO: How should we handle multiple?

--- a/tasks/rollback/init.js
+++ b/tasks/rollback/init.js
@@ -14,7 +14,7 @@ module.exports = function (gruntOrShipit) {
 
   function task() {
     var shipit = getShipit(gruntOrShipit);
-    _.assign(shipit.constructor.prototype, require('../../lib/releases'));
+    _.assign(shipit.constructor.prototype, require('../../lib/shipit'));
 
     return defineReleasePath()
     .then(function () {

--- a/tasks/rollback/init.js
+++ b/tasks/rollback/init.js
@@ -13,7 +13,9 @@ module.exports = function (gruntOrShipit) {
   registerTask(gruntOrShipit, 'rollback:init', task);
 
   function task() {
-    var shipit = require('../../lib/releases')(getShipit(gruntOrShipit));
+    var shipit = getShipit(gruntOrShipit);
+    _.assign(shipit.constructor.prototype, require('../../lib/releases'));
+
     return defineReleasePath()
     .then(function () {
       shipit.emit('rollback');

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -3,7 +3,7 @@ require('sinon-as-promised');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var publishFactory = require('../../../../tasks/deploy/publish');
-
+var path = require('path');
 describe('deploy:publish task', function () {
   var shipit;
 
@@ -24,6 +24,8 @@ describe('deploy:publish task', function () {
 
     shipit.releasePath = '/remote/deploy/releases/20141704123138';
     shipit.releaseDirname = '20141704123138';
+    shipit.currentPath = path.join(shipit.config.deployTo, 'current');
+    shipit.releasesPath = path.join(shipit.config.deployTo, 'releases');
 
     sinon.stub(shipit, 'remote').resolves();
   });

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -4,6 +4,7 @@ var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var publishFactory = require('../../../../tasks/deploy/publish');
 var path = require('path');
+
 describe('deploy:publish task', function () {
   var shipit;
 

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -96,7 +96,8 @@ describe('deploy:update task', function () {
 
     it('should update remote REVISION file', function (done) {
       shipit.start('deploy:update', function (err) {
-        shipit.getRevision('20141704123137').then(function(revision) {
+        shipit.getRevision('20141704123137')
+        .then(function(revision) {
           expect(revision).to.equal('9d63d434a921f496c12854a53cef8d293e2b4756');
           done();
         });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -4,6 +4,7 @@ var moment = require('moment');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var updateFactory = require('../../../../tasks/deploy/update');
+var path = require('path');
 
 describe('deploy:update task', function () {
   var shipit, clock;
@@ -25,6 +26,9 @@ describe('deploy:update task', function () {
         deployTo: '/remote/deploy'
       }
     });
+
+    shipit.currentPath = path.join(shipit.config.deployTo, 'current');
+    shipit.releasesPath = path.join(shipit.config.deployTo, 'releases');
 
     sinon.stub(shipit, 'remote').resolves();
     sinon.stub(shipit, 'remoteCopy').resolves();

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -102,6 +102,6 @@ describe('deploy:update task', function () {
         });
       });
     });
-
   });
+
 });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -133,15 +133,5 @@ describe('deploy:update task', function () {
       });
     });
 
-    // it('should update remote REVISION file', function (done) {
-    //   shipit.start('deploy:update', function (err) {
-    //     shipit.getRevision('20141704123137')
-    //     .then(function(revision) {
-    //       expect(revision).to.equal('9d63d434a921f496c12854a53cef8d293e2b4756');
-    //       done();
-    //     });
-    //   });
-    // });
   });
-
 });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -74,6 +74,12 @@ describe('deploy:update task', function () {
           );
         }
       });
+
+      sinon.stub(shipit, 'getRevision', function (releaseDir) {
+        if (releaseDir === '20141704123137') {
+          return Promise.resolve('9d63d434a921f496c12854a53cef8d293e2b4756');
+        }
+      });
     });
 
     afterEach(function () {
@@ -87,6 +93,15 @@ describe('deploy:update task', function () {
         done();
       });
     });
-  });
 
+    it('should update remote REVISION file', function (done) {
+      shipit.start('deploy:update', function (err) {
+        shipit.getRevision('20141704123137').then(function(revision) {
+          expect(revision).to.equal('9d63d434a921f496c12854a53cef8d293e2b4756');
+          done();
+        });
+      });
+    });
+
+  });
 });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -55,10 +55,10 @@ describe('deploy:update task', function () {
 
   describe('#setPreviousRevision', function () {
     describe('no previous revision', function () {
-      it('should set shipit.previousRevision to false', function (done) {
+      it('should set shipit.previousRevision to null', function (done) {
         shipit.start('deploy:update', function (err) {
           if (err) return done(err);
-          expect(shipit.previousRevision).to.equal(false);
+          expect(shipit.previousRevision).to.equal(null);
           done();
         });
       });

--- a/test/unit/tasks/rollback/init.js
+++ b/test/unit/tasks/rollback/init.js
@@ -42,7 +42,7 @@ describe('rollback:init task', function () {
 
       it('should return an error', function (done) {
         shipit.start('rollback:init', function (err) {
-          expect(err.message).to.equal('Remote server are not synced.');
+          expect(err.message).to.equal('Remote servers are not synced.');
           done();
         });
       });
@@ -91,7 +91,7 @@ describe('rollback:init task', function () {
 
       it('should return an error', function (done) {
         shipit.start('rollback:init', function (err) {
-          expect(err.message).to.equal('Remote server are not synced.');
+          expect(err.message).to.equal('Remote servers are not synced.');
           done();
         });
       });


### PR DESCRIPTION
Adds feature to track revisions for deployed releases: https://github.com/shipitjs/shipit/issues/34

Tests are passing, but I didn't add any specific tests for this stuff yet.
Just wanted to get it out here first.