### PR TITLE
Register tasks as blocking

### DIFF
--- a/tasks/deploy/clean.js
+++ b/tasks/deploy/clean.js
@@ -6,7 +6,7 @@ var utils = require('shipit-utils');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'deploy:clean', task);
+  utils.registerTask(gruntOrShipit, 'deploy:clean', task, false);
 
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -11,7 +11,7 @@ var Promise = require('bluebird');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'deploy:fetch', task);
+  utils.registerTask(gruntOrShipit, 'deploy:fetch', task, false);
 
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);

--- a/tasks/deploy/index.js
+++ b/tasks/deploy/index.js
@@ -21,5 +21,5 @@ module.exports = function (gruntOrShipit) {
     'deploy:update',
     'deploy:publish',
     'deploy:clean'
-  ]);
+  ], false);
 };

--- a/tasks/deploy/init.js
+++ b/tasks/deploy/init.js
@@ -8,7 +8,7 @@ var path = require('path2/posix');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'deploy:init', task);
+  utils.registerTask(gruntOrShipit, 'deploy:init', task, false);
 
   function task() {
     var shipit = init(utils.getShipit(gruntOrShipit));

--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -8,7 +8,7 @@ var path = require('path2/posix');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'deploy:publish', task);
+  utils.registerTask(gruntOrShipit, 'deploy:publish', task, false);
 
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -13,7 +13,7 @@ var _ = require('lodash');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'deploy:update', task);
+  utils.registerTask(gruntOrShipit, 'deploy:update', task, false);
 
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);

--- a/tasks/pending/index.js
+++ b/tasks/pending/index.js
@@ -11,5 +11,5 @@ module.exports = function (gruntOrShipit) {
 
   utils.registerTask(gruntOrShipit, 'pending', [
     'pending:log',
-  ]);
+  ], false);
 };

--- a/tasks/pending/log.js
+++ b/tasks/pending/log.js
@@ -9,7 +9,7 @@ var chalk = require('chalk');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'pending:log', task);
+  utils.registerTask(gruntOrShipit, 'pending:log', task, false);
 
   function task() {
     var shipit = init(utils.getShipit(gruntOrShipit));

--- a/tasks/rollback/index.js
+++ b/tasks/rollback/index.js
@@ -16,5 +16,5 @@ module.exports = function (gruntOrShipit) {
     'rollback:init',
     'deploy:publish',
     'deploy:clean'
-  ]);
+  ], false);
 };

--- a/tasks/rollback/init.js
+++ b/tasks/rollback/init.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
  */
 
 module.exports = function (gruntOrShipit) {
-  utils.registerTask(gruntOrShipit, 'rollback:init', task);
+  utils.registerTask(gruntOrShipit, 'rollback:init', task, false);
 
   function task() {
     var shipit = init(utils.getShipit(gruntOrShipit));


### PR DESCRIPTION
Since we need these tasks to be blocking, we need to either pass the sync flag (as in this PR), or we could change the default async param for `utils.registerTask`: https://github.com/shipitjs/shipit-utils/blob/master/lib/register-task.js#L5

Let me know which you prefer.