### PR TITLE
Make sure remote copy matches local workspace

### DIFF
--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -66,7 +66,7 @@ module.exports = function (gruntOrShipit) {
     function remoteCopy() {
       shipit.log('Copy project to remote servers.');
 
-      return shipit.remoteCopy(shipit.config.workspace + '/', shipit.releasePath)
+      return shipit.remoteCopy(shipit.config.workspace + '/', shipit.releasePath, {rsync: '--del'})
       .then(function () {
         shipit.log(chalk.green('Finished copy.'));
       });

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -41,7 +41,7 @@ module.exports = function (gruntOrShipit) {
       if (!shipit.previousRelease) {
         return Promise.resolve();
       }
-      return shipit.remote(util.format('cp -R %s/. %s', path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
+      return shipit.remote(util.format('cp -a %s/. %s', path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
     }
 
     /**


### PR DESCRIPTION
Central to this is that shared files were already present in the new release, because of the 'copy previous release before rsync' step. (I'm not using `shipit-shared` in this case.)

This adds flags to `cp` and `rsync` to ensure the remote release directory is what you expect after `deploy:update`.