### PR TITLE
Forced posix pathing

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var path = require('path2/posix');
 var _ = require('lodash');
 
 module.exports = function(shipit) {


### PR DESCRIPTION
Solves #51 by using an existing dependency. It's possible to get rid of the dependency if we require a 0.12.x Node version (which allows using `require('path').posix`); however, it's not really necessary.

It does not change functionality for existing users but it makes shipit work flawlessly on Windows (already tested it!)