### PR TITLE
Set current revision on remote after synching the workspace

### DIFF
--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -27,8 +27,8 @@ module.exports = function (gruntOrShipit) {
     .then(setPreviousRevision)
     .then(createReleasePath)
     .then(copyPreviousRelease)
-    .then(setCurrentRevision)
     .then(remoteCopy)
+    .then(setCurrentRevision)
     .then(function () {
       shipit.emit('updated');
     });


### PR DESCRIPTION
At the moment the file gets deleted directly after creation, due to the rsync with --delete