### PR TITLE
deploy to new and preexisting servers

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -59,7 +59,12 @@ Shipit.getCurrentReleaseDirname = function() {
   return shipit.remote(util.format('if [ -h %s ]; then readlink %s; fi', shipit.currentPath, shipit.currentPath))
   .then(function(results) {
     results = results || [];
-    var releaseDirnames = results.map(computeReleaseDirname);
+    var releaseDirnames = results
+      .map(computeReleaseDirname)
+      .filter(function(val) {
+        // Ignore new servers that have no pre-existing releases
+        return !!val;
+      });
 
     if (!equalValues(releaseDirnames)) {
       throw new Error('Remote servers are not synced.');


### PR DESCRIPTION
@neoziro Addresses https://github.com/shipitjs/shipit-deploy/issues/70

New servers won't have any "current release", but that shouldn't
be considered the same as an "out of sync" condition. This commit
filters out empty current release directories before checking if
all current releases on remote servers are in sync.