### PR TITLE
Unix-like environment in Windows fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shipit-deploy
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/shipitjs/shipit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/shipitjs/shipit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Build Status](https://travis-ci.org/shipitjs/shipit-deploy.svg?branch=master)](https://travis-ci.org/shipitjs/shipit-deploy)
 [![Dependency Status](https://david-dm.org/shipitjs/shipit-deploy.svg?theme=shields.io)](https://david-dm.org/shipitjs/shipit-deploy)
@@ -128,7 +128,7 @@ Several variables are attached during the deploy and the rollback process:
 
 ### shipit.config.*
 
-All options describe in the config sections are avalaible in the `shipit.config` object.
+All options described in the config sections are available in the `shipit.config` object.
 
 ### shipit.repository
 

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var path = require('path2/posix');
 var _ = require('lodash');
 var util = require('util');
 var Shipit = module.exports;

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -3,7 +3,7 @@ require('sinon-as-promised');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var publishFactory = require('../../../../tasks/deploy/publish');
-var path = require('path');
+var path = require('path2/posix');
 
 describe('deploy:publish task', function () {
   var shipit;

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -6,7 +6,7 @@ var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var updateFactory = require('../../../../tasks/deploy/update');
 var Promise = require('bluebird');
-var path = require('path');
+var path = require('path2/posix');
 
 var createShipitInstance = function (conf) {
   var shipit = new Shipit({

--- a/test/unit/tasks/pending/log.js
+++ b/test/unit/tasks/pending/log.js
@@ -3,7 +3,7 @@ require('sinon-as-promised');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var pendingFactory = require('../../../../tasks/pending/log');
-var path = require('path');
+var path = require('path2/posix');
 
 describe('pending:log task', function () {
   var shipit;

--- a/test/unit/tasks/rollback/finish.js
+++ b/test/unit/tasks/rollback/finish.js
@@ -2,7 +2,7 @@ var sinon = require('sinon');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var Shipit = require('shipit-cli');
 var finishFactory = require('../../../../tasks/rollback/finish');
-var path = require('path');
+var path = require('path2/posix');
 var Promise = require('bluebird');
 
 describe('rollback:finish task', function () {


### PR DESCRIPTION
Forces Posix in shipit.js (in lib) and all tests where it was relevant. Windows users running a UNIX-emulating terminal should be able to both pass all the tests, and be actually able to use the plugin with a remote UNIX server.

All due honesty, probably doesn't sort-out #72 in the spirit of that request, but should at least make it usable for some windows users.

Also includes a quick HTML escape and spellcheck in the README