### PR TITLE
Adds --tags to the `git fetch` Command

### DIFF
--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -95,7 +95,7 @@ module.exports = function (gruntOrShipit) {
     function fetch() {
       var fetchCommand = 'git fetch' +
         (shipit.config.shallowClone ? ' --depth=1 ' : ' ') +
-        'shipit -p';
+        'shipit -p --tags';
 
       shipit.log('Fetching repository "%s"', shipit.config.repositoryUrl);
 
@@ -122,7 +122,7 @@ module.exports = function (gruntOrShipit) {
         shipit.log(chalk.green('Checked out.'));
       });
     }
-    
+
     /**
      * Hard reset of working tree.
      */

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -47,7 +47,7 @@ describe('deploy:fetch task', function () {
         'git remote add shipit git://website.com/user/repo',
         {cwd: '/tmp/workspace'}
       );
-      expect(shipit.local).to.be.calledWith('git fetch shipit -p', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git fetch shipit -p --tags', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
       done();
@@ -67,7 +67,7 @@ describe('deploy:fetch task', function () {
         'git remote add shipit git://website.com/user/repo',
         {cwd: '/tmp/workspace'}
       );
-      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit -p', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit -p --tags', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
       done();


### PR DESCRIPTION
The `git fetch` command only pulls down tags that are reachable by the
current branch. There are cases where not all tags are reachable so not
all tags are fetched unless --tags is passed with fetch.

This commit adds --tags to the `git fetch` command to make sure the
`git checkout` command used by shipjs-deploy always succeeds if the
requested tag exists.

Updates tests to account for --tags.