### PR TITLE
Allow specifying the root drive/folder for RSYNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Set of deployment tasks for [Shipit](https://github.com/shipitjs/shipit) based o
 npm install shipit-deploy
 ```
 
+If you are deploying from Windows, you may want to have a look at the [wiki page about usage in Windows](https://github.com/shipitjs/shipit-deploy/wiki/Deploying-from-Windows).
+
 ## Usage
 
 ### Example `shipitfile.js`

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Type: `String`
 
 Log format to pass to [`git log`](http://git-scm.com/docs/git-log#_pretty_formats). Used to display revision diffs in `pending` task. Default: `%h: %s - %an`.
 
+### rsyncDrive
+
+Type: `String` *Optional*
+
+When deploying from Windows, set that to the drive letter containing the workspace folder. For example `/d` if your workspace is located in `d:\tmp\workspace`.
+
 ## Variables
 
 Several variables are attached during the deploy and the rollback process:

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -66,7 +66,11 @@ module.exports = function (gruntOrShipit) {
 
     function remoteCopy() {
       var uploadDirPath = path.resolve(shipit.config.workspace, shipit.config.dirToCopy || '');
-
+	    
+	    if (typeof shipit.config.rsyncDrive!=='undefined') {
+		    uploadDirPath = shipit.config.rsyncDrive + uploadDirPath;
+	    }
+	      
       shipit.log('Copy project to remote servers.');
       return shipit.remoteCopy(uploadDirPath + '/', shipit.releasePath, {rsync: '--del'})
       .then(function () {


### PR DESCRIPTION
This is in order to get things simple on Windows. Should not affect anything for the other systems.

I have documented the whole process and issues there: https://github.com/shipitjs/shipit-deploy/wiki/Deploying-from-Windows#workspace