### PR TITLE
Deploy finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The current symlink path : `path.join(shipit.config.deployTo, 'current')`.
   - deploy:clean
     - Remove old releases.
     - Emit event "cleaned".
+  - deploy:finish
+    - Emit event "deployed".
 - rollback
   - rollback:init
     - Define release path.

--- a/tasks/deploy/finish.js
+++ b/tasks/deploy/finish.js
@@ -1,0 +1,16 @@
+var utils = require('shipit-utils');
+var init = require('../../lib/init');
+
+/**
+ * Update task.
+ * - Emit an event "deployed".
+ */
+
+module.exports = function (gruntOrShipit) {
+  utils.registerTask(gruntOrShipit, 'deploy:finish', task);
+
+  function task() {
+    var shipit = init(utils.getShipit(gruntOrShipit));
+    shipit.emit('deployed');
+  }
+};

--- a/tasks/deploy/index.js
+++ b/tasks/deploy/index.js
@@ -6,6 +6,7 @@ var utils = require('shipit-utils');
  * - deploy:update
  * - deploy:publish
  * - deploy:clean
+ * - deploy:finish
  */
 
 module.exports = function (gruntOrShipit) {
@@ -14,12 +15,14 @@ module.exports = function (gruntOrShipit) {
   require('./update')(gruntOrShipit);
   require('./publish')(gruntOrShipit);
   require('./clean')(gruntOrShipit);
+  require('./finish')(gruntOrShipit);
 
   utils.registerTask(gruntOrShipit, 'deploy', [
     'deploy:init',
     'deploy:fetch',
     'deploy:update',
     'deploy:publish',
-    'deploy:clean'
+    'deploy:clean',
+    'deploy:finish'
   ]);
 };


### PR DESCRIPTION
For consistency with the rollback task, I have added a "deployed" event.

This is particularly useful when we want to run different tasks when the project is deployed or rolled-back.

Example: DB migration script on deploy + inverse DB migration script on rollback 
