### PR TITLE
Added submodule option for deployment task

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ module.exports = function (shipit) {
       keepReleases: 2,
       deleteOnRollback: false,
       key: '/path/to/key',
-      shallowClone: true
+      shallowClone: true,
+      updateSubmodules: false
     },
     staging: {
       servers: 'user@myserver.com'
@@ -121,6 +122,12 @@ Perform a shallow clone. Default: `false`.
 Type: `String`
 
 Log format to pass to [`git log`](http://git-scm.com/docs/git-log#_pretty_formats). Used to display revision diffs in `pending` task. Default: `%h: %s - %an`.
+
+### updateSubmodules
+
+Type: `Boolean`
+
+If your project uses submodules set this to true to pull in the submodules at deployment time.
 
 ## Variables
 

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -23,6 +23,7 @@ module.exports = function (gruntOrShipit) {
     .then(checkout)
     .then(reset)
     .then(merge)
+    .then(updateSubmodules)
     .then(function () {
       shipit.emit('fetched');
     });
@@ -95,8 +96,10 @@ module.exports = function (gruntOrShipit) {
     function fetch() {
       var fetchCommand = 'git fetch' +
         (shipit.config.shallowClone ? ' --depth=1 ' : ' ') +
-        'shipit -p --tags';
+        'shipit -p --tags' + 
+	(shipit.config.updateSubmodules ? ' --recurse-submodules' : '');
 
+      shipit.log('fetch submodules: ' + shipit.config.recursiveFetch);
       shipit.log('Fetching repository "%s"', shipit.config.repositoryUrl);
 
       return shipit.local(
@@ -169,6 +172,19 @@ module.exports = function (gruntOrShipit) {
       .then(function () {
         shipit.log(chalk.green('Branch merged.'));
       });
+    }
+
+    function updateSubmodules() {
+      if(shipit.config.updateSubmodules){
+	shipit.log('Updating submodules.');
+	return shipit.local(
+	  'git submodule update --init --recursive',
+	  {cwd: shipit.config.workspace}
+	)
+	.then(function () {
+	  shipit.log(chalk.green('Submodules updated'));
+	});
+      }
     }
   }
 };

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -99,7 +99,6 @@ module.exports = function (gruntOrShipit) {
         'shipit -p --tags' + 
 	(shipit.config.updateSubmodules ? ' --recurse-submodules' : '');
 
-      shipit.log('fetch submodules: ' + shipit.config.recursiveFetch);
       shipit.log('Fetching repository "%s"', shipit.config.repositoryUrl);
 
       return shipit.local(
@@ -175,15 +174,15 @@ module.exports = function (gruntOrShipit) {
     }
 
     function updateSubmodules() {
-      if(shipit.config.updateSubmodules){
-	shipit.log('Updating submodules.');
-	return shipit.local(
-	  'git submodule update --init --recursive',
-	  {cwd: shipit.config.workspace}
-	)
-	.then(function () {
-	  shipit.log(chalk.green('Submodules updated'));
-	});
+      if (shipit.config.updateSubmodules) {
+        shipit.log('Updating submodules.');
+        return shipit.local(
+            'git submodule update --init --recursive',
+            {cwd: shipit.config.workspace}
+        )
+            .then(function () {
+              shipit.log(chalk.green('Submodules updated'));
+            });
       }
     }
   }

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -73,4 +73,25 @@ describe('deploy:fetch task', function () {
       done();
     });
   });
+
+  it('should create workspace, create repo, checkout shallow call sync, and update submodules', function (done) {
+    shipit.config.shallowClone = true;
+    shipit.config.updateSubmodules = true;
+    shipit.start('deploy:fetch', function (err) {
+      if (err) return done(err);
+      expect(shipit.local).to.be.calledWith('rm -rf /tmp/workspace');
+      expect(mkdirpMock).to.be.calledWith('/tmp/workspace');
+      expect(shipit.local).to.be.calledWith('git init', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git remote', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith(
+          'git remote add shipit git://website.com/user/repo',
+          {cwd: '/tmp/workspace'}
+      );
+      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit -p --tags --recurse-submodules', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git submodule update --init --recursive', {cwd: '/tmp/workspace'});
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This adds submodule functionality requested in issue #77.  Because of the way shipit deploy gets code from git (fetch and checkout as opposed to clone) it is necessary to update the submodules in a separate step.  Have also added a config parameter 'updateSubmodules' to let people enable this.

Let me know if you think this useful and fits the workflow of shipit deploy and I will update the unit tests to cover this new feature.