### PR TITLE
Make git fetch fully compatible for version < 1.9

### DIFF
--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -96,7 +96,8 @@ module.exports = function (gruntOrShipit) {
       var fetchCommand = 'git fetch' +
         (shipit.config.shallowClone ? ' --depth=1 ' : ' ') +
         'shipit --prune';
-      fetchCommand = fetchCommand + ' && ' + fetchCommand + ' --tags';
+      // fetch branches and tags separate to be compatible with git versions < 1.9
+      fetchCommand += ' && ' + fetchCommand + ' "refs/tags/*:refs/tags/*"';
 
       shipit.log('Fetching repository "%s"', shipit.config.repositoryUrl);
 

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -95,7 +95,8 @@ module.exports = function (gruntOrShipit) {
     function fetch() {
       var fetchCommand = 'git fetch' +
         (shipit.config.shallowClone ? ' --depth=1 ' : ' ') +
-        'shipit -p --tags';
+        'shipit --prune';
+      fetchCommand = fetchCommand + ' && ' + fetchCommand + ' --tags';
 
       shipit.log('Fetching repository "%s"', shipit.config.repositoryUrl);
 

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -47,7 +47,7 @@ describe('deploy:fetch task', function () {
         'git remote add shipit git://website.com/user/repo',
         {cwd: '/tmp/workspace'}
       );
-      expect(shipit.local).to.be.calledWith('git fetch shipit -p --tags', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git fetch shipit --prune && git fetch shipit --prune "refs/tags/*:refs/tags/*"', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
       done();
@@ -67,7 +67,7 @@ describe('deploy:fetch task', function () {
         'git remote add shipit git://website.com/user/repo',
         {cwd: '/tmp/workspace'}
       );
-      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit -p --tags', {cwd: '/tmp/workspace'});
+      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit --prune && git fetch --depth=1 shipit --prune "refs/tags/*:refs/tags/*"', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
       done();


### PR DESCRIPTION
With the pull request #81 a bug was added to the master branch: `git fetch --tags` doesn't download all available branches for git versions 1.8 and older. To fetch all `git fetch` and `git fetch --tags` need to get run.
See for that this link: http://stackoverflow.com/questions/1204190/does-git-fetch-tags-include-git-fetch