### PR TITLE
feature : allow to skip the fetch step

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ shipit staging rollback
 
 Type: `String`
 
-Define a path to an empty directory where Shipit builds it's syncing source. **Beware to not set this path to the root of your repository as shipit-deploy cleans the directory at the given path as a first step.**
+Define a path to a directory where Shipit will prepare the files to be synced to the destination servers.
+
+By default, shipit will **cleans this directory as a first step** then `git clone` a fresh code copy into it. So **Beware to not set this path to the root of your repository**.
+
+If the `preFetched` option is set, then Shipit assumes that code is already fetched and will not erase nor `git clone` into this dir. The "fetched" event will be emited immediately without any action. It is then safe to set this option to the root of your repository.
 
 ### dirToCopy
 
@@ -115,6 +119,10 @@ Number of releases to keep on the remote server.
 Type: `Boolean`
 
 Perform a shallow clone. Default: `false`.
+
+### preFetched
+
+Assume that `workspace` already contains a valid clone of desired sources and do nothing during the fetch step. See the `workspace` option above.
 
 ### gitLogFormat
 

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -95,7 +95,7 @@ Shipit.getReleases = function() {
 /**
  * Return SHA from remote REVISION file.
  *
- * @param {string} releaseDir Directory name of the relesase dir (YYYYMMDDHHmmss).
+ * @param {string} releaseDir Directory name of the release dir (YYYYMMDDHHmmss).
  */
 
 Shipit.getRevision = function(releaseDir) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/shipitjs/shipit-deploy",
   "devDependencies": {
-    "bluebird": "^3.0.6",
     "chai": "^3.4.1",
     "mocha": "^2.1.0",
     "rewire": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "bluebird": "^2.9.1",
+    "bluebird": "^3.0.6",
     "chalk": "^1.0.0",
     "lodash": "^3.0.0",
     "mkdirp": "^0.5.0",

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -16,6 +16,13 @@ module.exports = function (gruntOrShipit) {
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);
 
+    if (shipit.config.preFetched) {
+      return Promise.resolve(true).then(function () {
+        shipit.log('Using pre-fetched workspace "%s", nothing to do.', shipit.config.workspace);
+        shipit.emit('fetched');
+      });
+    }
+    
     return createWorkspace()
     .then(initRepository)
     .then(addRemote)

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -31,6 +31,9 @@ module.exports = function (gruntOrShipit) {
     .then(setCurrentRevision)
     .then(function () {
       shipit.emit('updated');
+    })
+    .catch(function(err) {
+      shipit.log('Error while fetching !', err);
     });
 
     /**

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -87,7 +87,6 @@ module.exports = function (gruntOrShipit) {
 
       return shipit.getRevision(shipit.previousRelease)
       .then(function(revision) {
-
         if (revision) {
           shipit.log(chalk.green('Previous revision found.'));
           shipit.previousRevision = revision;
@@ -102,10 +101,10 @@ module.exports = function (gruntOrShipit) {
     function setPreviousRelease() {
       shipit.previousRelease = null;
       return shipit.getCurrentReleaseDirname()
-      .then(function(currentReleasseDirname) {
-        if (currentReleasseDirname) {
+      .then(function(currentReleaseDirname) {
+        if (currentReleaseDirname) {
           shipit.log(chalk.green('Previous release found.'));
-          shipit.previousRelease = currentReleasseDirname;
+          shipit.previousRelease = currentReleaseDirname;
         }
       });
     }

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -117,7 +117,8 @@ module.exports = function (gruntOrShipit) {
     function setCurrentRevision() {
       shipit.log('Setting current revision and creating revision file.');
 
-      return shipit.local('git rev-parse ' + shipit.config.branch, {cwd: shipit.config.workspace}).then(function(response) {
+      var cmd = 'git rev-parse ' + (shipit.config.preFetched ? 'HEAD' : shipit.config.branch);
+      return shipit.local(cmd, { cwd: shipit.config.workspace }).then(function(response) {
         shipit.currentRevision = response.stdout.trim();
         return shipit.remote('echo "' + shipit.currentRevision + '" > ' + path.join(shipit.releasePath, 'REVISION'));
       }).then(function() {

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -37,40 +37,54 @@ describe('deploy:fetch task', function () {
     shipit.local.restore();
   });
 
-  it('should create workspace, create repo, checkout and call sync', function (done) {
-    shipit.start('deploy:fetch', function (err) {
-      if (err) return done(err);
-      expect(mkdirpMock).to.be.calledWith('/tmp/workspace');
-      expect(shipit.local).to.be.calledWith('git init', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git remote', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith(
-        'git remote add shipit git://website.com/user/repo',
-        {cwd: '/tmp/workspace'}
-      );
-      expect(shipit.local).to.be.calledWith('git fetch shipit -p --tags', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
-      done();
+  context('when a fetch is required', function () {
+    it('should create workspace, create repo, checkout and call sync', function (done) {
+      shipit.start('deploy:fetch', function (err) {
+        if (err) return done(err);
+        expect(mkdirpMock).to.have.been.calledWith('/tmp/workspace');
+        expect(shipit.local).to.have.been.calledWith('git init', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git remote', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith(
+           'git remote add shipit git://website.com/user/repo',
+           {cwd: '/tmp/workspace'}
+        );
+        expect(shipit.local).to.have.been.calledWith('git fetch shipit -p --tags', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git checkout master', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
+        done();
+      });
+    });
+
+    it('should create workspace, create repo, checkout shallow and call sync', function (done) {
+      shipit.config.shallowClone = true;
+
+      shipit.start('deploy:fetch', function (err) {
+        if (err) return done(err);
+        expect(shipit.local).to.have.been.calledWith('rm -rf /tmp/workspace');
+        expect(mkdirpMock).to.have.been.calledWith('/tmp/workspace');
+        expect(shipit.local).to.have.been.calledWith('git init', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git remote', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith(
+           'git remote add shipit git://website.com/user/repo',
+           {cwd: '/tmp/workspace'}
+        );
+        expect(shipit.local).to.have.been.calledWith('git fetch --depth=1 shipit -p --tags', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git checkout master', {cwd: '/tmp/workspace'});
+        expect(shipit.local).to.have.been.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
+        done();
+      });
     });
   });
 
-  it('should create workspace, create repo, checkout shallow and call sync', function (done) {
-    shipit.config.shallowClone = true;
-
-    shipit.start('deploy:fetch', function (err) {
-      if (err) return done(err);
-      expect(shipit.local).to.be.calledWith('rm -rf /tmp/workspace');
-      expect(mkdirpMock).to.be.calledWith('/tmp/workspace');
-      expect(shipit.local).to.be.calledWith('git init', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git remote', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith(
-        'git remote add shipit git://website.com/user/repo',
-        {cwd: '/tmp/workspace'}
-      );
-      expect(shipit.local).to.be.calledWith('git fetch --depth=1 shipit -p --tags', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
-      expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
-      done();
+  context('when the workspace is already fetched', function () {
+    it('should do nothing', function (done) {
+      shipit.config.preFetched = true; // overwrite
+      shipit.start('deploy:fetch', function (err) {
+        if (err) return done(err);
+        expect(mkdirpMock).to.not.have.been.called;
+        expect(shipit.local).to.not.have.been.called;
+        done();
+      });
     });
   });
 });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -51,14 +51,10 @@ function restoreShipit(shipit) {
 }
 
 describe('deploy:update task', function () {
-  var shipit, clock;
+  var shipit;
 
   beforeEach(function () {
     shipit = createShipitInstance();
-    clock = sinon.useFakeTimers(1397730698075);
-  });
-  afterEach(function () {
-    clock.restore();
   });
 
   describe('update release', function () {
@@ -68,6 +64,7 @@ describe('deploy:update task', function () {
     afterEach(function () {
       shipit = restoreShipit(shipit);
     });
+
     it('should create release path, and do a remote copy', function (done) {
       shipit.start('deploy:update', function (err) {
         if (err) return done(err);
@@ -79,8 +76,6 @@ describe('deploy:update task', function () {
         expect(shipit.remoteCopy).to.be.calledWith('/tmp/workspace/', '/remote/deploy/releases/' + dirName);
         done();
       });
-
-      clock.tick(5);
     });
 
     describe('dirToCopy option', function () {
@@ -102,7 +97,6 @@ describe('deploy:update task', function () {
               if (err) reject(err);
               var dirName = moment.utc().format('YYYYMMDDHHmmss');
               expect(shipit.remoteCopy).to.be.calledWith(path.res, '/remote/deploy/releases/' + dirName);
-              clock.tick(5);
               resolve()
             })
           });


### PR DESCRIPTION
How do we launch a shipit deployment ? In most cases, we have to :
* `git clone` our repo to the label we want to deploy (to ensure we have the latest stable shipit files)
* `npm install --production`
* launch shipit (directly or with grunt).

Immediately, shipit will create a "workspace" and :
* `git clone` the exact same label
* and we'll most likely need to `npm install --production` again (there are even shipit modules for that)

This is inefficient. This PR add a "preFetched" option which, when set to true, instructs shipit to do nothing during the "fetch" step, considering it already done. We may then set `worspace: '.'` and avoid a git clone and a npm install.

Tests included. Also fix the tests which were broken, fix some typos, fix a double dependency.