### PR TITLE
Add cp parameter to shipit options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Type: `String`
 
 Log format to pass to [`git log`](http://git-scm.com/docs/git-log#_pretty_formats). Used to display revision diffs in `pending` task. Default: `%h: %s - %an`.
 
+### copy
+
+Type: `String`
+
+Parameter to pass to `cp` to copy the previous release. Non NTFS filesystems support `-r`. Default: `-a`
+
 ## Variables
 
 Several variables are attached during the deploy and the rollback process:

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -38,11 +38,12 @@ module.exports = function (gruntOrShipit) {
      */
 
     function copyPreviousRelease() {
+      var copyParameter = shipit.config.copy || '-a';
       if (!shipit.previousRelease) {
         return Promise.resolve();
       }
       shipit.log('Copy previous release to "%s"', shipit.releasePath);
-      return shipit.remote(util.format('cp -r %s/. %s', path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
+      return shipit.remote(util.format('cp %s %s/. %s', copyParameter, path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
     }
 
     /**

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -42,7 +42,7 @@ module.exports = function (gruntOrShipit) {
         return Promise.resolve();
       }
       shipit.log('Copy previous release to "%s"', shipit.releasePath);
-      return shipit.remote(util.format('cp -a %s/. %s', path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
+      return shipit.remote(util.format('cp -r %s/. %s', path.join(shipit.releasesPath, shipit.previousRelease), shipit.releasePath));
     }
 
     /**


### PR DESCRIPTION
Hello,

i added a parameter for the cp command which defaults to '-a' as it has been before. So it could work for every need.

Cheers.

See #103 