### PR TITLE
Fix #29, add warn for failed symbolic link creation, make symlink replace atomic

### DIFF
--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -30,9 +30,10 @@ module.exports = function (gruntOrShipit) {
       return shipit.remote(
         'cd ' + shipit.config.deployTo + ' && ' +
         'if [[ -d current && ! (-L current) ]]; then ' +
-        'ln -nfs ' + relativeReleasePath + ' current;' +
-        'else ' +
         'echo \"ERR: could not make symlink\"; ' +
+        'else ' +
+        'ln -nfs ' + relativeReleasePath + ' current_tmp && ' +
+        'mv -fT current_tmp current; ' +
         'fi'
       )
       .then(function (res) {

--- a/tasks/deploy/publish.js
+++ b/tasks/deploy/publish.js
@@ -35,10 +35,10 @@ module.exports = function (gruntOrShipit) {
         'echo \"ERR: could not make symlink\"; ' +
         'fi'
       )
-      .then(function (result) {
-        var failedresult = result.filter(function(r) {
-          return r.stdout.indexOf('could not make symlink') > -1;
-        });
+      .then(function (res) {
+        var failedresult = res ? res.stdout.filter(function(r) {
+          return r.indexOf('could not make symlink') > -1;
+        }) : [];
         if(failedresult.length && failedresult.length > 0) {
           shipit.log(chalk.yellow('Symbolic link at remote not made, as something already exists at ' + path(shipit.config.deployTo, 'current')));
         }

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -39,7 +39,7 @@ describe('deploy:publish task', function () {
     shipit.start('deploy:publish', function (err) {
       if (err) return done(err);
       expect(shipit.currentPath).to.equal('/remote/deploy/current');
-      expect(shipit.remote).to.be.calledWith('cd /remote/deploy && if [[ -d current && ! (-L current) ]]; then ln -nfs releases/20141704123138 current;else echo "ERR: could not make symlink"; fi');
+      expect(shipit.remote).to.be.calledWith('cd /remote/deploy && if [[ -d current && ! (-L current) ]]; then echo "ERR: could not make symlink"; else ln -nfs releases/20141704123138 current_tmp && mv -fT current_tmp current; fi');
       done();
     });
   });

--- a/test/unit/tasks/deploy/publish.js
+++ b/test/unit/tasks/deploy/publish.js
@@ -39,7 +39,7 @@ describe('deploy:publish task', function () {
     shipit.start('deploy:publish', function (err) {
       if (err) return done(err);
       expect(shipit.currentPath).to.equal('/remote/deploy/current');
-      expect(shipit.remote).to.be.calledWith('cd /remote/deploy && ln -nfs releases/20141704123138 current');
+      expect(shipit.remote).to.be.calledWith('cd /remote/deploy && if [[ -d current && ! (-L current) ]]; then ln -nfs releases/20141704123138 current;else echo "ERR: could not make symlink"; fi');
       done();
     });
   });


### PR DESCRIPTION
Functioning version of yamadapc 's original suggestion - a simple shell conditional and read through the stdout.

Throws yellow warning: `'Symbolic link at remote not made, as something already exists at ' + path(shipit.config.deployTo, 'current')`

Also included, a alternative symlinking replace mechanism that does the actual replace in a single atomic (mv) operation. 
