### PR TITLE
Fix workspace cleaning on Windows.

### DIFF
--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -44,7 +44,7 @@ module.exports = function (gruntOrShipit) {
 
       if (shipit.config.shallowClone) {
         shipit.log('Deleting existing workspace "%s"', shipit.config.workspace);
-        return shipit.local('rm -rf ' + shipit.config.workspace)
+        return shipit.local('rm -rf ..?* .[!.]* *', {cwd: shipit.config.workspace})
         .then(create);
       }
 

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -59,7 +59,7 @@ describe('deploy:fetch task', function () {
 
     shipit.start('deploy:fetch', function (err) {
       if (err) return done(err);
-      expect(shipit.local).to.be.calledWith('rm -rf /tmp/workspace');
+      expect(shipit.local).to.be.calledWith('rm -rf ..?* .[!.]* *', {cwd: '/tmp/workspace'});
       expect(mkdirpMock).to.be.calledWith('/tmp/workspace');
       expect(shipit.local).to.be.calledWith('git init', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git remote', {cwd: '/tmp/workspace'});


### PR DESCRIPTION
Hello,

I'm using Shipit on Windows with Git Bash and got the following error when running it twice :

```
Repository fetched.
Checking out commit-ish "XXX"
Running "git checkout XXX" on local.
@ Your branch and 'XXX' have diverged,
@ and have 1 and 1 different commits each, respectively.
@   (use "git pull" to merge the remote branch into yours)
@ Already on 'XXX'
Checked out.
Resetting the working tree
Running "git reset --hard HEAD" on local.
@ HEAD is now at XXX
Reset working tree.
Testing if commit-ish is a branch.
Running "git branch --list XXX" on local.
@ * XXX
Commit-ish is a branch, merging...
Running "git merge XXX" on local.
@ fatal: refusing to merge unrelated histories
```

I think this is because the workspace is not well deleted at the beginning of the process (mess between /tmp and /c/tmp) :

```
Deleting existing workspace "/tmp/XXX"
Running "rm -rf /tmp/XXX" on local.
Create workspace "/tmp/XXX"
Workspace created.
Initialize local repository in "/tmp/XXX"
Running "git init" on local.
@ Reinitialized existing Git repository in C:/tmp/XXX/.git/
```

This patch aims to fix this process.

Thanks and regards