### PR TITLE
Fixing Options header formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Type: `Boolean`
 
 Whether or not to delete the old release when rolling back to a previous release.
 
-#### key
+### key
 
 Type: `String`
 
@@ -124,7 +124,7 @@ Type: `Boolean`
 
 Perform a shallow clone. Default: `false`.
 
-###updateSubmodules
+### updateSubmodules
 
 Type: Boolean
 


### PR DESCRIPTION
Items in **Options** fixed:

* key:  Went from an h4 to an h3 to match neighbors
* updateSubmodules:  Added a space so that it would show appropriately as an h3