### PR TITLE
Allow fall back to default rsync config option

### DIFF
--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -66,7 +66,7 @@ module.exports = function (gruntOrShipit) {
      */
 
     function remoteCopy() {
-      var options = _.get(shipit.config, 'deploy.remoteCopy') || {rsync: '--del'};
+      var options = _.get(shipit.config, 'deploy.remoteCopy') || shipit.config.rsync || {rsync: '--del'};
       var rsyncFrom = shipit.config.rsyncFrom || shipit.config.workspace;
       var uploadDirPath = path.resolve(rsyncFrom, shipit.config.dirToCopy || '');
 


### PR DESCRIPTION
The shipit README mentions a potential rsync option in the global config (https://github.com/shipitjs/shipit-deploy#example-shipitfilejs) but it seems to be ignored by shipit-deploy.

This PR allows to fall back to it if it's provided, before using a default one.