### PR TITLE
Allow skipping "copy previous release" optimization by setting config.copy to false

### DIFF
--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -39,7 +39,7 @@ module.exports = function (gruntOrShipit) {
 
     function copyPreviousRelease() {
       var copyParameter = shipit.config.copy || '-a';
-      if (!shipit.previousRelease) {
+      if (!shipit.previousRelease || shipit.config.copy === false) {
         return Promise.resolve();
       }
       shipit.log('Copy previous release to "%s"', shipit.releasePath);


### PR DESCRIPTION
This optimization was slowing down our deploys by minutes, likely because our releases have a large node_modules dir that gets created on the server after the initial upload, which takes a long time to copy.

This patch allows you to set the `copy` config value to `false` to disable the optimization entirely.