### PR TITLE
Allows deploying without repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Type: `String`
 
 Git URL of the project repository.
 
+If empty Shipit will try to deploy without pulling the changes.
+
+In edge cases like quick PoC projects without a repository or a living on the edge production patch applying this can be helpful.
+
 ### branch
 
 Type: `String`

--- a/tasks/deploy/fetch.js
+++ b/tasks/deploy/fetch.js
@@ -16,6 +16,11 @@ module.exports = function (gruntOrShipit) {
 
   function task() {
     var shipit = utils.getShipit(gruntOrShipit);
+  
+    if (!shipit.config.repositoryUrl) {
+      shipit.log('Skipping fetching as no repository url was set.');
+      return;
+    }
 
     return createWorkspace()
     .then(initRepository)

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -119,6 +119,10 @@ module.exports = function (gruntOrShipit) {
      */
 
     function setCurrentRevision() {
+      if (!shipit.config.repositoryUrl) {
+        shipit.log('Skipping set current revision as not repository url was set.');
+        return;
+      }
       shipit.log('Setting current revision and creating revision file.');
 
       return shipit.local('git rev-parse ' + shipit.config.branch, {cwd: shipit.config.workspace}).then(function(response) {

--- a/test/unit/tasks/deploy/fetch.js
+++ b/test/unit/tasks/deploy/fetch.js
@@ -19,6 +19,7 @@ describe('deploy:fetch task', function () {
     fetchFactory(shipit);
 
     fetchFactory.__set__('mkdirp', mkdirpMock);
+    fetchFactory.__set__('rimraf', rimrafMock);
 
     // Shipit config
     shipit.initConfig({
@@ -35,6 +36,7 @@ describe('deploy:fetch task', function () {
 
   afterEach(function () {
     mkdirpMock.reset();
+    rimrafMock.reset();
     shipit.local.restore();
   });
 
@@ -71,6 +73,16 @@ describe('deploy:fetch task', function () {
       expect(shipit.local).to.be.calledWith('git fetch shipit --prune --depth=1 && git fetch shipit --prune "refs/tags/*:refs/tags/*"', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git checkout master', {cwd: '/tmp/workspace'});
       expect(shipit.local).to.be.calledWith('git branch --list master', {cwd: '/tmp/workspace'});
+      done();
+    });
+  });
+  
+  it('should do nothing when reposity url is empty', function (done) {
+    delete shipit.config.repositoryUrl;
+    
+    shipit.start('deploy:fetch', function (err) {
+      if (err) return done(err);
+      expect(mkdirpMock).callCount(0);
       done();
     });
   });

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -20,6 +20,7 @@ var createShipitInstance = function (conf) {
   shipit.initConfig({
     test: _.merge({
       workspace: '/tmp/workspace',
+      repositoryUrl: 'git://website.com/user/repo',
       deployTo: '/remote/deploy'
     }, conf)
   });
@@ -251,6 +252,16 @@ describe('deploy:update task', function () {
           expect(revision).to.equal('9d63d434a921f496c12854a53cef8d293e2b4756');
           done();
         });
+      });
+    });
+  
+    it('should not set revision if no repository url is present', function (done) {
+      delete shipit.config.repositoryUrl;
+      
+      shipit.start('deploy:update', function (err) {
+        if (err) return done(err);
+        expect(shipit.currentRevision).to.equal(undefined);
+        done();
       });
     });
 


### PR DESCRIPTION
In some edge cases it's nice to deploy without fetching from repo repository - for example for automation tests, generating source code for deployment etc.
This change allows it with some warning like message for those who accidentally didn't pass repositoryUrl in config.

As a bonus tests regression introduced with rimraf lib are fixed.