### PR TITLE
Add option to skip checking that all server have same revision 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Type: `String`
 
 Parameter to pass to `cp` to copy the previous release. Non NTFS filesystems support `-r`. Default: `-a`
 
+### skipServerSyncCheck
+
+Type: `Boolean`
+
+Skip validation that remote servers are synced.
+
 ## Variables
 
 Several variables are attached during the deploy and the rollback process:

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -61,9 +61,9 @@ Shipit.getCurrentReleaseDirname = function() {
     results = results || [];
     var releaseDirnames = results.map(computeReleaseDirname);
 
-    // if (!equalValues(releaseDirnames)) {
-    //   throw new Error('Remote servers are not synced.');
-    // }
+    if (!shipit.config.skipServerSyncCheck && !equalValues(releaseDirnames)) {
+      throw new Error('Remote servers are not synced.');
+    }
 
     if (!releaseDirnames[0]) {
       shipit.log('No current release found.');
@@ -85,8 +85,8 @@ Shipit.getReleases = function() {
   .then(function(results) {
     var releases = results.map(computeReleases);
 
-    // if (!equalValues(releases))
-    //   throw new Error('Remote servers are not synced.');
+    if (!shipit.config.skipServerSyncCheck && !equalValues(releases))
+      throw new Error('Remote servers are not synced.');
 
     return releases[0];
   });

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -61,9 +61,9 @@ Shipit.getCurrentReleaseDirname = function() {
     results = results || [];
     var releaseDirnames = results.map(computeReleaseDirname);
 
-    if (!equalValues(releaseDirnames)) {
-      throw new Error('Remote servers are not synced.');
-    }
+    // if (!equalValues(releaseDirnames)) {
+    //   throw new Error('Remote servers are not synced.');
+    // }
 
     if (!releaseDirnames[0]) {
       shipit.log('No current release found.');
@@ -85,8 +85,8 @@ Shipit.getReleases = function() {
   .then(function(results) {
     var releases = results.map(computeReleases);
 
-    if (!equalValues(releases))
-      throw new Error('Remote servers are not synced.');
+    // if (!equalValues(releases))
+    //   throw new Error('Remote servers are not synced.');
 
     return releases[0];
   });


### PR DESCRIPTION
This option should allow deploing not synced servers  https://github.com/shipitjs/shipit/issues/66

It probably will not work well with rollback